### PR TITLE
Bugfix: Correct language directory.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -150,7 +150,7 @@ if (!function_exists('ap_core_setup')) {
         require_once( get_template_directory() . '/inc/class-bootstrap-nav-walker.php' );
 
         // i18n stuff
-        load_theme_textdomain('museum-core', get_template_directory() .'/language');
+        load_theme_textdomain('museum-core', get_template_directory() .'/lang');
 
         // html5 theme support
         add_theme_support( 'html5' );


### PR DESCRIPTION
Sorry to bother you again, but it seems that there is a small bug in the newest release: You have all your translations in the "lang" sub directory. But in the functions.php you referred to the default location "language". Due to that, the translations are no longer working.