### PR TITLE
Fix bug that leads to wrong archive titles.

### DIFF
--- a/parts/content-archive.php
+++ b/parts/content-archive.php
@@ -2,8 +2,7 @@
 
 	<?php /* If this is a category archive */
 	if ( is_category() ) {
-		$category = get_the_category();
-		$category = $category[0]->cat_name; ?>
+		$category = single_cat_title( '', false ); ?>
 	    <h2 class="the_title"><?php echo esc_attr( sprintf( __( 'Posts filed under %s','museum-core'), $category ) ); ?></h2>
 
 	<?php /* If this is a tag archive */


### PR DESCRIPTION
If a post belonging to multiple categories is the uppermost on a archive
page showing only posts belonging to one category the title of the page
will always show the first category of the first post. This commit
solves this problem.