### PR TITLE
strip 'http:' from font URLs to improve HTTPS support

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -82,13 +82,13 @@ if (!function_exists('ap_core_load_scripts')) {
         wp_register_script('modernizr',get_template_directory_uri() . '/assets/js/modernizr-2.5.3.min.js',false,'2.5.3');
         wp_enqueue_script('modernizr');
         // register fonts
-        wp_register_style('droidsans','http://fonts.googleapis.com/css?family=Droid+Sans&subset=' . $font_subset,false,$theme['Version']);
-        wp_register_style('ptserif','http://fonts.googleapis.com/css?family=PT+Serif&subset=' . $font_subset,false,$theme['Version']);
-        wp_register_style('inconsolata','http://fonts.googleapis.com/css?family=Inconsolata&subset=' . $font_subset,false,$theme['Version']);
-        wp_register_style('ubuntu','http://fonts.googleapis.com/css?family=Ubuntu&subset=' . $font_subset,false,$theme['Version']);
-        wp_register_style('lato','http://fonts.googleapis.com/css?family=Lato&subset=' . $font_subset,false,$theme['Version'] );
-        wp_register_style( 'notoserif','http://fonts.googleapis.com/css?family=Noto+Serif&subset=' . $font_subset,false, $theme['Version']  );
-        wp_register_style( 'opensans', 'http://fonts.googleapis.com/css?family=Open+Sans&subset=' . $font_subset, false, $theme['Version'] );
+        wp_register_style('droidsans','//fonts.googleapis.com/css?family=Droid+Sans&subset=' . $font_subset,false,$theme['Version']);
+        wp_register_style('ptserif','//fonts.googleapis.com/css?family=PT+Serif&subset=' . $font_subset,false,$theme['Version']);
+        wp_register_style('inconsolata','//fonts.googleapis.com/css?family=Inconsolata&subset=' . $font_subset,false,$theme['Version']);
+        wp_register_style('ubuntu','//fonts.googleapis.com/css?family=Ubuntu&subset=' . $font_subset,false,$theme['Version']);
+        wp_register_style('lato','//fonts.googleapis.com/css?family=Lato&subset=' . $font_subset,false,$theme['Version'] );
+        wp_register_style( 'notoserif','//fonts.googleapis.com/css?family=Noto+Serif&subset=' . $font_subset,false, $theme['Version']  );
+        wp_register_style( 'opensans', '//fonts.googleapis.com/css?family=Open+Sans&subset=' . $font_subset, false, $theme['Version'] );
         // only enqueue fonts that are actually being used
         $heading = ( isset( $options['heading'] ) ) ? $options['heading'] : $defaults['heading'];
         $body = ( isset( $options['body'] ) ) ? $options['body'] : $defaults['body'];


### PR DESCRIPTION
'http:' in the font URLs was creating problems with my newly implemented Content Security Policy which required HTTPS origins. Removing the explicit protocol reference will make the resources adopt whichever is in use in the parent page. Should correct any mixed content warnings as well.